### PR TITLE
Remove branch-defaults setting from eb config.yml

### DIFF
--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -1,8 +1,3 @@
-branch-defaults:
-  staging:
-    environment: ais-api-staging
-  master:
-    environment: ais-api-prod
 global:
   application_name: ais-api
   default_ec2_keyname: ais-api-dev


### PR DESCRIPTION
In our deployment process, the environment is always explicitly specified. Also, `eb list` places an asterisk before the default environment if there is one. This may work against, e.g., iterating through the list with a bash for loop