### PR TITLE
Docs: add link in readme to API Usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AIS provides a unified view of City data for an address.
 
+[API usage documentation](https://github.com/CityOfPhiladelphia/ais/blob/master/docs/APIUSAGE.md).
+
 ## Goals
 
 - Simplify relationships between land records, real estate properties, streets, and addresses


### PR DESCRIPTION
I figure this is one of the most often sought pages in this repo.