### PR TITLE
Add floor field to AIS response

### DIFF
--- a/ais/api/serializers.py
+++ b/ais/api/serializers.py
@@ -395,6 +395,7 @@ class AddressJsonSerializer (GeoJSONSerializer):
                 ('street_postdir', address.street_postdir),
                 ('unit_type', address.unit_type),
                 ('unit_num', address.unit_num),
+                ('floor', address.floor),
                 ('street_full', address.street_full),
                 ('street_code', address.street_code),
                 ('seg_id', address.seg_id),

--- a/ais/api/views.py
+++ b/ais/api/views.py
@@ -355,7 +355,7 @@ def addresses(query):
         strict_filters.update(dict(unit_type=unit_type or '', ))
 
     filters.update(strict_filters)
-    print(filters)
+    # print(filters)
 
     if search_type not in ('address', 'street') or low_num is None:
         error = json_error(404, 'Not a valid address.',
@@ -372,7 +372,7 @@ def addresses(query):
         return addresses
 
     def process_query(addresses, match_type):
-        print(addresses)
+        # print(addresses)
         addresses = addresses.include_child_units(
             'include_units' in request.args and request.args['include_units'].lower() != 'false',
             is_range=False if range else high_num_full is not None,
@@ -587,7 +587,7 @@ def block(query):
 
     # Ensure that we have results
     addresses_count = paginator.collection_size
-    #print(addresses_count)
+    # print(addresses_count)
     if addresses_count == 0:
         if 'opa_only' in request.args and request.args['opa_only'].lower() != 'false':
             error = json_error(404, 'Could not find any opa addresses matching query.',

--- a/ais/api/views.py
+++ b/ais/api/views.py
@@ -355,6 +355,7 @@ def addresses(query):
         strict_filters.update(dict(unit_type=unit_type or '', ))
 
     filters.update(strict_filters)
+    print(filters)
 
     if search_type not in ('address', 'street') or low_num is None:
         error = json_error(404, 'Not a valid address.',
@@ -371,7 +372,7 @@ def addresses(query):
         return addresses
 
     def process_query(addresses, match_type):
-
+        print(addresses)
         addresses = addresses.include_child_units(
             'include_units' in request.args and request.args['include_units'].lower() != 'false',
             is_range=False if range else high_num_full is not None,
@@ -380,6 +381,7 @@ def addresses(query):
             .exclude_non_opa('opa_only' in request.args and request.args['opa_only'].lower() != 'false') \
             .get_address_geoms(request) \
             .order_by_address()
+        
 
         # Get tag data
         # if not addresses.all():

--- a/ais/engine/scripts/load_addresses.py
+++ b/ais/engine/scripts/load_addresses.py
@@ -462,6 +462,16 @@ def main():
             }
             links.append(base_link)
 
+            # Floor link, first attempt
+            if address.floor is not None and address.unit_type != 'FL': # e.g. 100 S BROAD ST FL 11 STE 1100
+                address_with_floor = f"{address.base_address} FL {address.floor}"
+                floor_link = {
+                    'address_1': address.street_address,
+                    'relationship': 'on floor',
+                    'address_2': address_with_floor,
+                }
+                links.append(floor_link)
+
             # Sibling generic unit links
             # These relate unit addresses to all other addresses that share the same
             # generic unit. Bidirectional.

--- a/ais/engine/scripts/load_addresses.py
+++ b/ais/engine/scripts/load_addresses.py
@@ -59,14 +59,14 @@ def main():
     WRITE_OUT = True
 
     DEV = False  # This will target a single address
-    DEV_ADDRESS = "920-22 W GIRARD AVE"
+    DEV_ADDRESS = "1231 N BROAD ST FL 3"
     DEV_ADDRESS_COMPS = {
         # 'base_address':      '1 FRANKLIN TOWN BLVD',
         # 'address_high':     '4726',
         # 'street_name':      'ALDEN',
         # 'street_suffix':    'WALK',
     }
-    DEV_STREET_NAME = 'W GIRARD AVE'
+    DEV_STREET_NAME = 'N BROAD ST'
 
     # Logging stuff.
     address_errors = []
@@ -217,6 +217,8 @@ def main():
                     raise ValueError('Unknown address type')
 
                 address = Address(parsed_address)
+                if DEV: #added for debug 05/25
+                    print(vars(address))
 
                 # Get street address and map to source address
                 street_address = address.street_address

--- a/ais/engine/scripts/load_dor_parcels.py
+++ b/ais/engine/scripts/load_dor_parcels.py
@@ -417,6 +417,7 @@ def main():
                 #Remove fields not in parcel tables:
                 parcel.pop('zip_code', None)
                 parcel.pop('zip_4', None)
+                parcel.pop('floor', None)
                 #Add fields:
                 parcel.update({
                     'parcel_id':        parcel_id,

--- a/ais/engine/scripts/load_pwd_parcels.py
+++ b/ais/engine/scripts/load_pwd_parcels.py
@@ -117,6 +117,7 @@ def main():
             # Remove fields not in parcel tables:
             parcel.pop('zip_code', None)
             parcel.pop('zip_4', None)
+            parcel.pop('floor', None)
             # Add fields:
             parcel.update({
                 parcel_geom_field:	geometry,

--- a/ais/engine/scripts/make_linked_tags.py
+++ b/ais/engine/scripts/make_linked_tags.py
@@ -246,6 +246,8 @@ def main():
     print('Looping through {} addresses...'.format(len(address_rows))) # Remove this
     for address_row in address_rows:
         i+=1
+        if i % 10000 == 0:
+            print(f"Now on address {i} at {datetime.now()}")
         unit_num = address_row['unit_num']
         street_address = address_row['street_address']
         low_num = address_row['address_low']

--- a/ais/engine/scripts/make_linked_tags.py
+++ b/ais/engine/scripts/make_linked_tags.py
@@ -90,7 +90,7 @@ def main():
     cleanup(geocode_file)
     
     #define traversal order
-    traversal_order = ['has generic unit', 'matches unit', 'has base', 'overlaps', 'in range']
+    traversal_order = ['has generic unit', 'matches unit', 'on floor', 'has base', 'overlaps', 'in range']
     
     print('Reading addresses...')
     address_file = 'address.csv'

--- a/ais/models.py
+++ b/ais/models.py
@@ -243,6 +243,7 @@ ADDRESS_FIELDS = [
     'street_postdir',
     'unit_type',
     'unit_num',
+    'floor',
     'street_full',
     'street_address',
     'zip_code',

--- a/ais/models.py
+++ b/ais/models.py
@@ -287,6 +287,7 @@ class Address(db.Model):
     street_postdir = db.Column(db.Text)
     unit_type = db.Column(db.Text)
     unit_num = db.Column(db.Text)
+    floor = db.Column(db.Text)
     street_full = db.Column(db.Text)
     zip_code = db.Column(db.Text)
     zip_4 = db.Column(db.Text)
@@ -362,6 +363,7 @@ class Address(db.Model):
             'street_postdir':       c['street']['postdir'],
             'unit_type':            c['address_unit']['unit_type'],                # passyunk change
             'unit_num':             c['address_unit']['unit_num'],                 # passyunk change
+            'floor':                c['floor']['floor_num'],                # added to passyunk spring 2025
             'street_full':          c['street']['full'],
             'street_address':       c['output_address'],
             'zip_code':             c['mailing']['zipcode'],

--- a/ais/models.py
+++ b/ais/models.py
@@ -1206,7 +1206,7 @@ class AddressSummary(db.Model):
     street_postdir = db.Column(db.Text)
     unit_type = db.Column(db.Text)
     unit_num = db.Column(db.Text)
-    floor = db.Column(db.Text) # do I want/need this?
+    floor = db.Column(db.Text)
     street_full = db.Column(db.Text)
     zip_code = db.Column(db.Text)
     zip_4 = db.Column(db.Text)

--- a/ais/models.py
+++ b/ais/models.py
@@ -1205,6 +1205,7 @@ class AddressSummary(db.Model):
     street_postdir = db.Column(db.Text)
     unit_type = db.Column(db.Text)
     unit_num = db.Column(db.Text)
+    floor = db.Column(db.Text) # do I want/need this?
     street_full = db.Column(db.Text)
     zip_code = db.Column(db.Text)
     zip_4 = db.Column(db.Text)

--- a/config.py
+++ b/config.py
@@ -273,6 +273,7 @@ ADDRESSES = {
         'usps_bldgfirm': ['mailing', 'bldgfirm'],
         'election block_id': ['election', 'blockid'],
         'election precinct': ['election', 'precinct'],
+        'floor': ['floor', 'floor_num']
     },
 
     'sources': [

--- a/config.py
+++ b/config.py
@@ -273,7 +273,6 @@ ADDRESSES = {
         'usps_bldgfirm': ['mailing', 'bldgfirm'],
         'election block_id': ['election', 'blockid'],
         'election precinct': ['election', 'precinct'],
-        'floor': ['floor', 'floor_num']
     },
 
     'sources': [

--- a/docs/APIUSAGE.md
+++ b/docs/APIUSAGE.md
@@ -187,6 +187,7 @@ The root of the `FeatureCollection` contains:
   * `street_postdir` (e.g. 190 N INDEPENDENCE MALL **W**)
   * `unit_type` (APT, STE, FL, #, UNIT, etc.)
   * `unit_num`
+  * `floor` (e.g. 1234 MARKET ST FL **15**)
   * `street_full` (e.g., **N BROAD ST**)
   * `zip_code`
   * `zip_4`


### PR DESCRIPTION
- add a "floor" field to the db.Models for Address, NG911AddressPoint, and AddressSummary, and to AddressSerializer and AddressTagSerializer
- extract value for that field from passyunk response's `address['components']['floor']['floor_num']` field
- pop that field during load_dor_parcels.py and load_pwd_parcels.py scripts to prevent errors in database build
- add "on floor" relationship for linked tags

**This should not be merged until ais-build-dev-matt server has a chance to build overnight on 5/29, and I can verify that it works without bugs**